### PR TITLE
"Last Update" column now also shows if plugin has been closed or doesn't exist on the .ord repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,15 @@
 Plugins Last Updated Column
 =
 ---
-This plugin adds columns to the admin plugin's page to show when each plugin was last updated or upgraded.
-The functionality of this plugin was entirely [Karissa Skirmont](http://kissaskreations.com/ "Kissa's Kreations")'s idea.
+This plugin adds two columns to the plugin's page in WordPress's admin to show when each plugin was "Last Updated" by the developer and when the plugin was "Last Upgraded" on the site. The "Last Updated" column will also show "Plugin not found" OR "Plugin has been closed!" if the plugin isn't on the repo anymore or has been closed.
+
+The first time you load the plugins page, it will load very slowly due to many API calls made to WordPress.org in order to retrieve the last updated information.
+
+This plugin makes 1 API call for each plugin installed. This data is cached for 24 hours, unless you manually clear the cache clearing via Admin Menu > Plugins > Plugin Columns.
+
+
+The idea for this plugin's functionality and the artwork was by [Karissa Skirmont](http://karissaskirmont.com "karissaskirmont.com")'s of [Profoundly Purple](http://profoundlypurple.com "profoundlypurple.com").
+Plugin Developed by [Steven Kohlmeyer](http://stevenkohlmeyer.com "stevenkohlmeyer.com") with contributions by [Michael Preslar (http://drzimp.com "drzimp.com")].
 
 [Plugin Page](https://wordpress.org/plugins/plugins-last-updated-column/#developers "Plugins Last Updated Column")
 
@@ -26,11 +33,12 @@ Artwork compliments of [Karissa Skirmont](http://kissaskreations.com/ "Kissa's K
 
 ---
 
-Changelot
+Changelog
 =
 * 0.1.4
   * Last Updated Column now displays if the plugin has been closed or isn't on the repo
   * getPluginsLastUpdated() now respects WP_DEBUG
+  * Updated plugin description
 * 0.1.3
   * Fixed debug warnings
 * 0.1.2

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,11 @@ Artwork compliments of [Karissa Skirmont](http://kissaskreations.com/ "Kissa's K
 
 Changelot
 =
+* 0.1.4
+  * Last Updated Column now displays if the plugin has been closed or isn't on the repo
+  * getPluginsLastUpdated() now respects WP_DEBUG
+* 0.1.3
+  * Fixed debug warnings
 * 0.1.2
   * Version number bump
 * 0.1.1

--- a/readme.txt
+++ b/readme.txt
@@ -1,27 +1,35 @@
 === Plugins Last Updated Column ===
-Contributors: Fastmover, karissa
-Tags: plugins, plugins last updated, last updated, updated
+Contributors: Fastmover, karissa, drzimp
+Tags: plugins, plugins last updated, last updated, updated, plugin closed
 Requires at least: 3.7
 Tested up to: 6.5.2
 Stable tag: 0.1.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-This plugin adds columns to the admin plugin's page to show when each plugin was last updated and upgraded.
+This plugin adds 2 columns to the admin plugin's page to show when each plugin was last updated and upgraded.
 
 == Description ==
 
-This plugin adds a column to the plugin's page in WordPress's admin to show when each plugin was last updated. This causes the plugins page to load very slowly on the first page load due to many API calls made to wordPress.org in order to retrieve the last updated information.  This plugin makes 1 API call for each plugin installed.  This data is cached for 24 hours. The functionality of this plugin was entirely [Karissa Skirmont](http://kissaskreations.com/ "Kissa's Kreations")'s idea. [Plugin Page](http://stevenkohlmeyer.com/plugins-last-updated-column/ "Plugins Last Updated Column").  Artwork compliments of [Karissa](http://kissaskreations.com/ "Kissa's Kreations")
+This plugin adds two columns to the plugin's page in WordPress's admin to show when each plugin was "Last Updated" by the developer and when the plugin was "Last Upgraded" on the site. The "Last Updated" column will also show "Plugin not found" OR "Plugin has been closed!" if the plugin isn't on the repo anymore or has been closed. 
+
+The first time you load the plugins page, it may load very slowly if you have a lot of plugins due to many API calls made to WordPress.org in order to retrieve the last updated information. 
+
+This plugin makes 1 API call for each plugin installed. This data is cached for 24 hours, unless you manually clear the cache clearing via Admin Menu > Plugins > Plugin Columns.
+
+
+The idea for this plugin's functionality and the artwork was by [Karissa Skirmont](http://karissaskirmont.com "karissaskirmont.com")'s of [Profoundly Purple](http://profoundlypurple.com "profoundlypurple.com"). 
+Plugin Developed by [Steven Kohlmeyer](http://stevenkohlmeyer.com "stevenkohlmeyer.com") with contributions by [Michael Preslar (http://drzimp.com "drzimp.com")].
 
 == Installation ==
 
-1. Install this plugin either via the WordPress.org plugin directory, or by uploading the files to your server
-2. Activate the plugin through the 'Plugins' menu in WordPress
-3. That's it. You're ready to go!
+1. Install this plugin either via the WordPress.org plugin directory, or by uploading the files to your server.
+2. Activate the plugin through the 'Plugins' menu in WordPress. If in a Multisite install, "Network Activate" to show on ALL sites in the install or only Activate individually on a per site basis.
+3. That's it. You're ready to go clean up your plugin list of old or closed plugins!
 
 == Screenshots ==
 
-1. As you can see, the plugins table now has 2 columns on the right side labeled: Last Updated and Last Upgraded.
+1. The plugins table has 2 columns on the right side labeled: Last Updated and Last Upgraded.
 2. A page dedicated to clearing cache on the Last Updated Column.
 3. Shows a WordPress MultiSite Network Plugin page with last updated / last upgraded columns.
 
@@ -30,6 +38,7 @@ This plugin adds a column to the plugin's page in WordPress's admin to show when
 = 0.1.4 =
 * Last Updated Column now displays if the plugin has been closed or isn't on the repo
 * getPluginsLastUpdated() now respects WP_DEBUG
+* Updated description
 
 = 0.1.3 =
 * Fixed debug warnings
@@ -75,3 +84,4 @@ This plugin adds a column to the plugin's page in WordPress's admin to show when
 
 = 0.0.1 =
 * Plugin adds a last updated column to the plugins page of the admin.
+

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
-=== Plugin Name ===
+=== Plugins Last Updated Column ===
 Contributors: Fastmover, karissa
 Tags: plugins, plugins last updated, last updated, updated
 Requires at least: 3.7
 Tested up to: 6.5.2
-Stable tag: 0.1.2
+Stable tag: 0.1.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -26,6 +26,13 @@ This plugin adds a column to the plugin's page in WordPress's admin to show when
 3. Shows a WordPress MultiSite Network Plugin page with last updated / last upgraded columns.
 
 == Changelog ==
+
+= 0.1.4 =
+* Last Updated Column now displays if the plugin has been closed or isn't on the repo
+* getPluginsLastUpdated() now respects WP_DEBUG
+
+= 0.1.3 =
+* Fixed debug warnings
 
 = 0.1.2 =
 * Version bump - Plugin still works as expected with Wordpress 6.5.2

--- a/sk-plugins-last-updated-column.php
+++ b/sk-plugins-last-updated-column.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Plugins Last Updated Column
  * Plugin URI: http://stevenkohlmeyer.com/plugins-last-updated-column/
- * Description: This plugin adds a 'Last Updated' column to the admin plugins page.
+ * Description: This plugin adds 'Last Updated' and 'Last Upgraded' columns to the admin plugins page.
  * Version: 0.1.4
  * Author: Fastmover
  * Author URI: http://StevenKohlmeyer.com
@@ -15,7 +15,7 @@ if ( ! defined ( 'ABSPATH' ) ) {
 
 class SK_Plugins_Last_Updated_Column
 {
-    public $cacheTime    = 1800;
+    public $cacheTime    = 86400;
     public $slugUpdated  = "sk-plugin-last-updated ";
     public $slugUpgraded = "sk-plugin-last-upgraded ";
     public $slugSettings = "plugins-last-updated-settings";

--- a/sk-plugins-last-updated-column.php
+++ b/sk-plugins-last-updated-column.php
@@ -3,7 +3,7 @@
  * Plugin Name: Plugins Last Updated Column
  * Plugin URI: http://stevenkohlmeyer.com/plugins-last-updated-column/
  * Description: This plugin adds a 'Last Updated' column to the admin plugins page.
- * Version: 0.1.2
+ * Version: 0.1.4
  * Author: Fastmover
  * Author URI: http://StevenKohlmeyer.com
  * License: GPLv2 or later
@@ -85,7 +85,27 @@ class SK_Plugins_Last_Updated_Column
         <span class="lastUpdatedMobileTitle">Last Updated: </span>
         <?php
 
-        if ( $lastUpdated !== "-1" && $lastUpdated !== -1 ) {
+        if ( $lastUpdated === false ) {
+           ?>
+           <span>Not Avail.</span>
+           <?php
+
+        } elseif ( is_numeric( $lastUpdated ) )  {
+            if ( $lastUpdated == -2 ) {
+                ?>
+                <strong class="plugin-last-updated-humanreadable" data-color="#ff0000"><strong>Plugin has been closed!</strong>
+                <?php
+        } elseif ( $lastUpdated == -3 ) {
+                ?>
+                <strong class="plugin-last-updated-humanreadable" data-color="#ff0000">Plugin not found</strong>
+                <?php
+            } else {
+                ?>
+                <span>Not Avail.</span>
+                <?php
+            }
+
+            } else {
 
             if ( ! $this->currentDateTime ) {
                 $this->currentDateTime = new DateTime();
@@ -120,20 +140,11 @@ class SK_Plugins_Last_Updated_Column
 
             ?>
             <span><?php echo $dateLastUpdated; ?></span>
-
-            <?php
-
-        } else {
-            ?>
-            <span>Not Avail.</span>
-            <?php
-        }
-
-        ?>
-        <br/>
-        <span class="plugin-last-updated-humanreadable" data-color="<?php echo $color; ?>"
-              style="background-color: <?php echo $color; ?>"><?php echo $msg; ?></span>
+            <br/>
+            <span class="plugin-last-updated-humanreadable" data-color="<?php echo $color; ?>"
+                  style="background-color: <?php echo $color; ?>"><?php echo $msg; ?></span>
         <?php
+        }
     }
 
     public function columnLastUpgraded ( $columnName, $pluginFile, $pluginData )
@@ -184,8 +195,11 @@ class SK_Plugins_Last_Updated_Column
     function getPluginsLastUpdated ( $pluginSlug )
     {
 
+        $retval = get_transient ( $this->slugUpdated . $pluginSlug );
 
-        if ( ! get_transient ( $this->slugUpdated . $pluginSlug ) ) {
+        if ( ( $retval !== false ) && ( ! defined('WP_DEBUG') || ! WP_DEBUG ) ) {
+            return $retval;
+        }
 
             include_once ( ABSPATH . 'wp-admin/includes/plugin-install.php' );
 
@@ -199,9 +213,42 @@ class SK_Plugins_Last_Updated_Column
 
             /** Check for Errors & Display the results */
             if ( is_wp_error ( $call_api ) ) {
-                set_transient ( $this->slugUpdated . $pluginSlug, -1, $this->cacheTime );
 
-                return -1;
+                /*
+                 * plugin_api() doesn't differentiate between a network issue and a successful
+                 * API request that returns json that contains a key of "error". Examples:
+                 * {"error":"Plugin not found."}
+                 * 
+                   {
+                    "error": "closed",
+                    "name": "Easy Testimonials",
+                    "slug": "easy-testimonials",
+                    "description": "This plugin has been closed as of July 19, 2024 and is not available for download. Reason: Security Issue.",
+                    "closed": true,
+                    "closed_date": "2024-07-19",
+                    "reason": "security-issue",
+                    "reason_text": "Security Issue"
+                  }
+
+                 * Unfortunately, plugin_api() also doesn't pass the returned json into WP_Error,
+                 * so we can't get the "reason" or "closed_date". Best we can do is check the
+                 * error message and go from there.
+                 */
+
+                $retval = false;
+                $errmsg = $call_api->get_error_message();
+
+                if ( $errmsg == 'closed' ) { 
+                    $retval = -2;
+                } elseif ( $errmsg == 'Plugin not found.' ) {
+                    $retval = -3;
+                }
+
+                if ( $retval !== false ) {
+                    set_transient ( $this->slugUpdated . $pluginSlug, $retval, $this->cacheTime );
+                }
+
+                return $retval;
             } else {
                 if ( ! empty( $call_api->last_updated ) ) {
                     set_transient ( $this->slugUpdated . $pluginSlug, $call_api->last_updated,
@@ -209,18 +256,10 @@ class SK_Plugins_Last_Updated_Column
 
                     return $call_api->last_updated;
                 } else {
-                    set_transient ( $this->slugUpdated . $pluginSlug, -1, $this->cacheTime );
 
-                    return -1;
+                    return false;
                 }
             }
-
-        } else {
-            //Debugging purposes:
-            //delete_transient( 'sk_plugins_last_updated' . $pluginSlug );
-
-            return get_transient ( $this->slugUpdated . $pluginSlug );
-        }
     }
 
     function columnHeading ( $columns )


### PR DESCRIPTION
This changes the "Last Updated" column to show if the plugin has been closed on the wordpress.org repo, or if the plugin doesn't exist on the .org repo.

The getPluginsLastUpdated() function now also respects WP_DEBUG

$cacheTime has been updated to 24 hours, instead of 30 minutes

Documentation and descriptions have been updated. Version numbers have been updated to 0.1.4

Finally: GitHub only had up to 0.1.2, however 0.1.3 was on the wordpress.org repo, so these changes also include the 0.1.3 updates.

With all changes in place, this could be packaged up as is and sent on to the wp.org repo.